### PR TITLE
Fix SSR issue caused by webpack 4

### DIFF
--- a/webpack.prod.config.js
+++ b/webpack.prod.config.js
@@ -7,7 +7,8 @@ module.exports = {
     path: path.resolve(__dirname, 'dist'),
     filename: 'react-items-carousel.js',
     library: 'ReactItemsCarousel',
-    libraryTarget: 'umd'
+    libraryTarget: 'umd',
+    globalObject: "typeof self !== 'undefined' ? self : this"
   },
   externals: [nodeExternals()],
   module: {


### PR DESCRIPTION
Webpack 4's UMD builds are now incompatible with nodejs by default as they expect `window` to be defined. This changes the config to be compatible with the way it worked in V3.

Here is the Webpack issue: [webpack/webpack#6522](https://github.com/webpack/webpack/issues/6522)

Fixes #2 