### PR TITLE
fix "Warning: Received NaN for the `width` attribute. If this is expe…

### DIFF
--- a/src/ItemsCarousel/index.js
+++ b/src/ItemsCarousel/index.js
@@ -240,7 +240,7 @@ class ItemsCarousel extends React.Component {
           children={({ translateX }) => this.renderList({ items, measureRef, containerWidth, translateX })}
         />
         {
-          _showRightChevron && 
+          _showRightChevron &&
           <CarouselRightChevron
             chevronWidth={chevronWidth}
             outsideChevron={outsideChevron}
@@ -256,7 +256,7 @@ class ItemsCarousel extends React.Component {
           </CarouselRightChevron>
         }
         {
-          _showLeftChevron && 
+          _showLeftChevron &&
           <CarouselLeftChevron
             chevronWidth={chevronWidth}
             outsideChevron={outsideChevron}
@@ -284,8 +284,8 @@ class ItemsCarousel extends React.Component {
       >
         {({ measureRef, contentRect }) => {
           return this.renderContent({
-            containerWidth: contentRect.bounds.width,
-            containerHeight: contentRect.bounds.height,
+            containerWidth: contentRect.bounds.width || 0,
+            containerHeight: contentRect.bounds.height || 0,
             measureRef,
           });
         }}
@@ -316,7 +316,7 @@ ItemsCarousel.propTypes = {
   showSlither: PropTypes.bool,
 
   /**
-   * If true first item will have twice the 
+   * If true first item will have twice the
    */
   firstAndLastGutter: PropTypes.bool,
 


### PR DESCRIPTION
fix Warning: Received NaN for the `width` attribute. If this is expected, cast the value to a string.

The Warning comes from  `SliderItem` which is a `styled-component` that expects a number for width prop.

On the first render cycle the `contentRect.bounds.width` from react measure will return `undefined` and the value goes to `calculateItemWidth` method that will return `NaN` for the first render cycle of the `SliderItem`

Setting the `containerWidth` with 0 instead of `undefined` for the first render cycle will fix the warning with no side-effects