### PR TITLE
Adding infinite loop feature to the carousel

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -2,6 +2,7 @@ root = true
 
 [*]
 end_of_line = lf
-insert_final_newline = false
+insert_final_newline = true
+trim_trailing_whitespace = true
 indent_style = space
 indent_size = 2

--- a/README.md
+++ b/README.md
@@ -1,17 +1,14 @@
 react-items-carousel
 ---------------
 
-Installing
-------------
+# Installation
 ```
 $ npm install react-items-carousel --save
 ```
 
-[Demos](https://bitriddler.github.io/react-items-carousel/)
---------------
+# [Demos](https://bitriddler.github.io/react-items-carousel/)
 
-Example
---------------
+# Example
 
 ```javascript
 import React, { useState } from 'react';
@@ -42,12 +39,15 @@ export default () => {
 };
 ```
 
+# Component Props
+
 | Property                 | Type                             | Default | Description                                                                           |
 |--------------------------|----------------------------------|---------|---------------------------------------------------------------------------------------|
 | children *               | node[]                           |         | The cards to render in the carousel. You must specify a height for each card.         |
 | requestToChangeActive *  | function                         |         | This function accepts the new activeItemIndex and should update your component state. |
 | activeItemIndex *        | int                              |         | This defines which item should be active.                                             |
 | numberOfCards            | number                           | 3       | Number of cards to show per slide.                                                    |
+| infiniteLoop             | boolean                          | false   | Enable infinite loop. see [Infinite loop limitations](#inifinite-loop-limitations)                                                                  |
 | gutter                   | number                           | 0       | Space between cards.                                                                  |
 | showSlither              | boolean                          | false   | If true a slither of next card will be shown.                                         |
 | firstAndLastGutter       | boolean                          | false   | If true first and last cards will have twice the space.                               |
@@ -63,10 +63,15 @@ export default () => {
 | slidesToScroll           | number                           | 1       | Number of cards to scroll when right and left chevrons are clicked.                   |
 | disableSwipe             | boolean                          | false   | Disables left and right swiping on touch devices.                                     |
 | onStateChange            | func                             | null    | This function will be called when state change with `{ isFirstScroll: Boolean, isLastScroll: Boolean }`. It can be used to fetch more data for example. |
-| classes                  | `{ wrapper: string, itemsWrapper: string, itemsInnerWrapper: string, itemWrapper: string, rightChevronWrapper: string, leftChevronWrapper: string }` | {}      | An object of classes to pass to the carousel inner elements | 
+| classes                  | `{ wrapper: string, itemsWrapper: string, itemsInnerWrapper: string, itemWrapper: string, rightChevronWrapper: string, leftChevronWrapper: string }` | {}      | An object of classes to pass to the carousel inner elements |
 
-Contributing
---------------
+
+# Infinite Loop Limitations
+If `infiniteLoop` was set to true, the following props are ignored
+- `activePosition`: will always be `left`
+- `alwaysShowChevrons`: will always be `true`
+
+# Contributing
 To contribute, follow these steps:
 - Fork this repo.
 - Clone your fork.
@@ -75,6 +80,5 @@ To contribute, follow these steps:
 - Goto `localhost:9000`
 - Add your patch then push to your fork and submit a pull request
 
-License
----------
+# License
 MIT

--- a/gh/components/CarouselSlideItem.js
+++ b/gh/components/CarouselSlideItem.js
@@ -32,6 +32,23 @@ export const SlideItem = styled.div`
   background-position: center;
 `;
 
+const SlideItemIndex = styled.div`
+  color: #FFF;
+  font-weight: bold;
+  font-size: 16px;
+  background: #333;
+  border: 2px solid #000;
+  border-left: 0;
+  border-top: 0;
+  width: 30px;
+  height: 30px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+`;
+
 export const createImageChildren = n => range(n).map((i) => (
-  <SlideItem key={i} src={items[i%items.length]} />
+  <SlideItem key={i} src={items[i%items.length]}>
+    <SlideItemIndex>{i}</SlideItemIndex>
+  </SlideItem>
 ));

--- a/gh/components/InfiniteLoopDemo.js
+++ b/gh/components/InfiniteLoopDemo.js
@@ -1,0 +1,44 @@
+import React, { useState } from 'react';
+import styled from 'styled-components';
+import { Button, Icon, Col } from 'antd';
+import ItemsCarousel from '../../src/ItemsCarousel';
+import { createImageChildren } from './CarouselSlideItem';
+
+const noOfItems = 7;
+const noOfCards = 2;
+const chevronWidth = 60;
+
+const Wrapper = styled.div`
+  padding: 0 20px;
+  max-width: 1000px;
+  margin: 0 auto;
+`;
+
+const carouselItems = createImageChildren(noOfItems);
+
+export default () => {
+  const [activeItemIndex, setActiveItemIndex] = useState(0);
+  return (
+    <Wrapper>
+      <ItemsCarousel
+        infiniteLoop
+        gutter={12}
+        numberOfCards={noOfCards}
+        activeItemIndex={activeItemIndex}
+        requestToChangeActive={setActiveItemIndex}
+        rightChevron={
+          <Button shape="circle">
+            <Icon type="right" />
+          </Button>
+        }
+        leftChevron={
+          <Button shape="circle">
+            <Icon type="left" />
+          </Button>
+        }
+        chevronWidth={chevronWidth}
+        children={carouselItems}
+      />
+    </Wrapper>
+  );
+};

--- a/gh/components/variations.js
+++ b/gh/components/variations.js
@@ -4,6 +4,7 @@ const mainState = {
   noOfChildren: 10,
   wrapperStyle: { padding: "0 60px", maxWidth: 800, margin: '0 auto' },
   componentProps: {
+    infiniteLoop: false,
     gutter: 12,
     activePosition: 'center',
     chevronWidth: 60,

--- a/gh/page.js
+++ b/gh/page.js
@@ -5,12 +5,21 @@ import Playground from './components/Playground';
 import pckJson from '../package.json';
 import PlaceholderDemo from './components/PlaceholderDemo';
 import AutoPlayCarousel from './components/AutoPlayCarousel';
+import InfiniteLoopDemo from './components/InfiniteLoopDemo';
+import InfiniteLoopDemoString from '!!raw-loader!./components/InfiniteLoopDemo';
 import DemoHeader from './components/DemoHeader';
 import AutoPlayCarouselString from '!!raw-loader!./components/AutoPlayCarousel';
 import CenteredRow from './components/CenteredRow';
 import JsxEditor from './components/JsxEditor';
 
 const { Content, Footer, Header } = Layout;
+
+const enableDemos = {
+  playground: true,
+  infiniteLoop: true,
+  placeholder: true,
+  autoPlay: true,
+}
 
 const Page = () => (
   <Layout>
@@ -25,20 +34,46 @@ const Page = () => (
     </Header>
     <Content style={{ overflowX: 'hidden', background: '#FFF' }}>
       <Hero version={pckJson.version} />
-      <Playground />
-      <Divider />
-      <PlaceholderDemo />
-      <Divider/>
-      <DemoHeader
-        title={'Autoplay'}
-        description={'Example that shows how to extend the carousel to add autoplay functionality'}
-      />
-      <AutoPlayCarousel/>
-      <CenteredRow withMaxWidth>
-        <Col span={24}>
-          <JsxEditor value={AutoPlayCarouselString} />
-        </Col>
-      </CenteredRow>
+      {enableDemos.playground && (
+        <>
+          <Playground />
+          <Divider />
+        </>
+      )}
+      {enableDemos.infiniteLoop && (
+        <>
+          <DemoHeader
+            title={'Infinite Loop'}
+          />
+          <InfiniteLoopDemo />
+          <CenteredRow withMaxWidth>
+            <Col span={24}>
+              <JsxEditor value={InfiniteLoopDemoString} />
+            </Col>
+          </CenteredRow>
+          <Divider />
+        </>
+      )}
+      {enableDemos.placeholder && (
+        <>
+          <PlaceholderDemo />
+          <Divider/>
+        </>
+      )}
+      {enableDemos.autoPlay && (
+        <>
+          <DemoHeader
+            title={'Autoplay'}
+            description={'Example that shows how to extend the carousel to add autoplay functionality'}
+          />
+          <AutoPlayCarousel/>
+          <CenteredRow withMaxWidth>
+            <Col span={24}>
+              <JsxEditor value={AutoPlayCarouselString} />
+            </Col>
+          </CenteredRow>
+        </>
+      )}
     </Content>
     <Footer style={{ background: '#FFF' }}>
       © 2019 <a href="http://www.bitriddler.com">bitriddler</a> | Kareem Elbahrawy

--- a/package.json
+++ b/package.json
@@ -24,8 +24,7 @@
     "lint": "eslint src"
   },
   "pre-commit": [
-    "lint",
-    "doc"
+    "lint"
   ],
   "keywords": [
     "react-items-carousel",

--- a/src/ItemsCarousel/ItemsCarouselBase.js
+++ b/src/ItemsCarousel/ItemsCarouselBase.js
@@ -101,14 +101,17 @@ class ItemsCarouselBase extends React.Component {
       firstAndLastGutter,
       showSlither,
       classes,
+      calculateActualTranslateX,
     } = this.props;
+
+    const actualTranslateX = calculateActualTranslateX(translateX);
 
     return (
       <Wrapper className={classes.itemsWrapper}>
         <SliderItemsWrapper
           ref={measureRef}
           style={{
-            transform: `translateX(${translateX * -1}px)`,
+            transform: `translateX(${actualTranslateX * -1}px)`,
           }}
           className={classes.itemsInnerWrapper}
         >
@@ -157,7 +160,6 @@ class ItemsCarouselBase extends React.Component {
       gutter,
       numberOfCards,
       firstAndLastGutter,
-      activeItemIndex,
       activePosition,
       springConfig,
       showSlither,
@@ -238,7 +240,6 @@ ItemsCarouselBase.defaultProps = {
 
 ItemsCarouselBase.propTypes = {
   ...userPropTypes,
-
   // Props coming from withCarouselValues
   items: PropTypes.arrayOf(PropTypes.node).isRequired,
   activeItemTranslateX: PropTypes.number.isRequired,

--- a/src/ItemsCarousel/ItemsCarouselBase.js
+++ b/src/ItemsCarousel/ItemsCarouselBase.js
@@ -7,7 +7,6 @@ import {
   calculateItemWidth,
   calculateItemLeftGutter,
   calculateItemRightGutter,
-  calculateTranslateX,
   showLeftChevron,
   showRightChevron,
   calculateNextIndex,
@@ -74,9 +73,8 @@ class ItemsCarouselBase extends React.Component {
       activeItemIndex,
       activePosition,
       slidesToScroll,
+      items,
     } = this.props;
-
-    const items = this.getItems();
 
     return {
       isLastScroll: !showRightChevron({
@@ -94,21 +92,6 @@ class ItemsCarouselBase extends React.Component {
         slidesToScroll,
       })
     }
-  };
-
-  getItems = () => {
-    const {
-      isPlaceholderMode,
-      placeholderItem,
-      numberOfPlaceholderItems,
-      children
-    } = this.props;
-
-    if (isPlaceholderMode) {
-      return Array.from(Array(numberOfPlaceholderItems)).map(index => placeholderItem);
-    }
-
-    return React.Children.toArray(children);
   };
 
   renderList({ items, translateX, containerWidth, measureRef }) {
@@ -186,20 +169,11 @@ class ItemsCarouselBase extends React.Component {
       slidesToScroll,
       alwaysShowChevrons,
       classes,
+      items,
+      activeItemTranslateX,
+      nextItemIndex,
+      previousItemIndex,
     } = this.props;
-
-    const items = this.getItems();
-
-    const translateX = calculateTranslateX({
-      activeItemIndex,
-      activePosition,
-      containerWidth,
-      numberOfChildren: items.length,
-      numberOfCards,
-      gutter,
-      firstAndLastGutter,
-      showSlither,
-    });
 
     const {
       isFirstScroll,
@@ -217,10 +191,10 @@ class ItemsCarouselBase extends React.Component {
       >
         <Motion
           defaultStyle={{
-            translateX,
+            translateX: activeItemTranslateX,
           }}
           style={{
-            translateX: spring(translateX + touchRelativeX, springConfig),
+            translateX: spring(activeItemTranslateX + touchRelativeX, springConfig),
           }}
           children={({ translateX }) => this.renderList({
             items,
@@ -235,13 +209,7 @@ class ItemsCarouselBase extends React.Component {
             chevronWidth={chevronWidth}
             outsideChevron={outsideChevron}
             className={classes.rightChevronWrapper}
-            onClick={() => requestToChangeActive(calculateNextIndex({
-              activePosition,
-              activeItemIndex,
-              numberOfCards,
-              slidesToScroll,
-              numberOfChildren: items.length,
-            }))}
+            onClick={() => requestToChangeActive(nextItemIndex)}
           >
             {rightChevron}
           </CarouselRightChevron>
@@ -252,13 +220,7 @@ class ItemsCarouselBase extends React.Component {
             chevronWidth={chevronWidth}
             outsideChevron={outsideChevron}
             className={classes.leftChevronWrapper}
-            onClick={() => requestToChangeActive(calculatePreviousIndex({
-              activePosition,
-              activeItemIndex,
-              numberOfCards,
-              slidesToScroll,
-              numberOfChildren: items.length,
-            }))}
+            onClick={() => requestToChangeActive(previousItemIndex)}
           >
             {leftChevron}
           </CarouselLeftChevron>
@@ -276,8 +238,12 @@ ItemsCarouselBase.defaultProps = {
 
 ItemsCarouselBase.propTypes = {
   ...userPropTypes,
-  // Props coming from withPlaceholderMode
-  isPlaceholderMode: PropTypes.bool.isRequired,
+
+  // Props coming from withCarouselValues
+  items: PropTypes.arrayOf(PropTypes.node).isRequired,
+  activeItemTranslateX: PropTypes.number.isRequired,
+  nextItemIndex: PropTypes.number.isRequired,
+  previousItemIndex: PropTypes.number.isRequired,
   // Props coming from withContainerWidth
   containerWidth: PropTypes.number.isRequired,
   measureRef: PropTypes.oneOfType([

--- a/src/ItemsCarousel/helpers.js
+++ b/src/ItemsCarousel/helpers.js
@@ -86,7 +86,7 @@ export const calculateLastPossibleTranslateX = ({
   return translateX;
 }
 
-export const calculateTranslateX = ({
+export const calculateActiveItemTranslateX = ({
   activeItemIndex,
   activePosition,
   containerWidth,
@@ -246,4 +246,3 @@ export const calculatePreviousIndex = ({
       ]);
   }
 }
-

--- a/src/ItemsCarousel/helpers.js
+++ b/src/ItemsCarousel/helpers.js
@@ -95,6 +95,7 @@ export const calculateActiveItemTranslateX = ({
   gutter,
   firstAndLastGutter,
   showSlither,
+  infiniteLoop,
 }) => {
   let gotoIndex = activeItemIndex;
 
@@ -106,18 +107,18 @@ export const calculateActiveItemTranslateX = ({
     gotoIndex -= numberOfCards - 1;
   }
 
-  // Items are larger than container then 
+  // Items are larger than container then
   if(areItemsLargerThanContainer({ numberOfChildren, numberOfCards })) {
     return 0;
   }
 
   // The first item
-  if(gotoIndex <= 0) {
+  if(!infiniteLoop && gotoIndex <= 0) {
     return 0;
   }
 
   // Last items to show
-  if(gotoIndex > (numberOfChildren - numberOfCards - 1)) {
+  if(!infiniteLoop && gotoIndex > (numberOfChildren - numberOfCards - 1)) {
     return calculateLastPossibleTranslateX({
       activeItemIndex: gotoIndex,
       activePosition,

--- a/src/ItemsCarousel/index.js
+++ b/src/ItemsCarousel/index.js
@@ -6,11 +6,19 @@ import ItemsCarouselBase from './ItemsCarouselBase';
 import userPropTypes from './userPropTypes';
 import withPlaceholderMode from './withPlaceholderMode';
 import withCarouselValues from './withCarouselValues';
+import withInfiniteLoopCarouselValues from './infiniteLoop/withInfiniteLoopCarouselValues';
+
+const hocFuncValuesSwitcher = () => (Cpmt) => (props) => {
+  const canEnableInfiniteLoop = React.Children.toArray(props.children).length >= props.numberOfCards;
+  return props.infiniteLoop && canEnableInfiniteLoop ?
+    withInfiniteLoopCarouselValues()(Cpmt)(props) :
+    withCarouselValues()(Cpmt)(props);
+}
 
 const ItemsCarousel = pipe(
   withSwipe(),
   withPlaceholderMode(),
-  withCarouselValues(),
+  hocFuncValuesSwitcher(),
   withContainerWidth(),
 )(ItemsCarouselBase);
 
@@ -32,6 +40,8 @@ ItemsCarousel.defaultProps = {
   onActiveStateChange: null,
   alwaysShowChevrons: false,
   classes: {},
+  infiniteLoop: false,
+  calculateActualTranslateX: translateX => translateX,
 };
 
 export default ItemsCarousel;

--- a/src/ItemsCarousel/index.js
+++ b/src/ItemsCarousel/index.js
@@ -5,11 +5,13 @@ import pipe from './pipe';
 import ItemsCarouselBase from './ItemsCarouselBase';
 import userPropTypes from './userPropTypes';
 import withPlaceholderMode from './withPlaceholderMode';
+import withCarouselValues from './withCarouselValues';
 
 const ItemsCarousel = pipe(
   withSwipe(),
-  withContainerWidth(),
   withPlaceholderMode(),
+  withCarouselValues(),
+  withContainerWidth(),
 )(ItemsCarouselBase);
 
 ItemsCarousel.propTypes = userPropTypes;

--- a/src/ItemsCarousel/infiniteLoop/helpers.js
+++ b/src/ItemsCarousel/infiniteLoop/helpers.js
@@ -1,0 +1,96 @@
+import min from 'lodash.min';
+import max from 'lodash.max';
+import { calculateActiveItemTranslateX } from '../helpers';
+
+const getItems =  (items, { numberOfCards }) => {
+  return [
+    ...items.slice(items.length - numberOfCards),
+    ...items,
+    ...items.slice(0, numberOfCards),
+  ];
+};
+
+const getPreviousItemIndex = ({
+  activeItemIndex,
+  slidesToScroll,
+}) =>  activeItemIndex - slidesToScroll;
+
+const getNextItemIndex = ({
+  activeItemIndex,
+  slidesToScroll,
+}) => activeItemIndex + slidesToScroll;
+
+const getActiveItemIndex = ({
+  activeItemIndex,
+  numberOfCards,
+}) => activeItemIndex;
+
+const getActiveItemTranslateX = ({
+  activeItemIndex,
+  activePosition,
+  containerWidth,
+  numberOfChildren,
+  numberOfCards,
+  gutter,
+  firstAndLastGutter,
+  showSlither,
+}) => calculateActiveItemTranslateX({
+  activeItemIndex,
+  activePosition,
+  containerWidth,
+  numberOfChildren,
+  numberOfCards,
+  gutter,
+  firstAndLastGutter,
+  showSlither,
+  infiniteLoop: true,
+});
+
+const getActualTranslateX = (items, currentTranslateX, {
+  activePosition,
+  containerWidth,
+  numberOfCards,
+  gutter,
+  firstAndLastGutter,
+  showSlither,
+}) => {
+  const lastTranslateX = getActiveItemTranslateX({
+    numberOfChildren: items.length,
+    activeItemIndex: items.length - numberOfCards*2,
+    activePosition,
+    containerWidth,
+    numberOfCards,
+    gutter,
+    firstAndLastGutter,
+    showSlither,
+  });
+
+  const leftShift = getActiveItemTranslateX({
+    numberOfChildren: items.length,
+    activeItemIndex: numberOfCards,
+    activePosition,
+    containerWidth,
+    numberOfCards,
+    gutter,
+    firstAndLastGutter,
+    showSlither,
+  });
+
+
+  const actualTranslateX = currentTranslateX%lastTranslateX + leftShift;
+
+  if (actualTranslateX <= 0) {
+    return lastTranslateX - Math.abs(actualTranslateX);
+  }
+
+  return actualTranslateX;
+}
+
+export default {
+  getItems,
+  getPreviousItemIndex,
+  getNextItemIndex,
+  getActiveItemIndex,
+  getActiveItemTranslateX,
+  getActualTranslateX,
+};

--- a/src/ItemsCarousel/infiniteLoop/withInfiniteLoopCarouselValues.js
+++ b/src/ItemsCarousel/infiniteLoop/withInfiniteLoopCarouselValues.js
@@ -1,0 +1,74 @@
+import React from 'react';
+import infiniteLoopHelpers from './helpers';
+
+const withInfiniteLoopCarouselValues = () => (Cpmt) => (props) => {
+  const {
+    calculateActualTranslateX: userCalculateActualTranslateX,
+    numberOfCards,
+    activeItemIndex: oldActiveItemIndex,
+    numberOfChildren,
+    slidesToScroll,
+    containerWidth,
+    gutter,
+    firstAndLastGutter,
+    showSlither,
+    children
+  } = props;
+
+  const activePosition = 'left';
+
+  const items = infiniteLoopHelpers.getItems(React.Children.toArray(children), { numberOfCards });
+
+  const activeItemIndex = infiniteLoopHelpers.getActiveItemIndex({
+    activeItemIndex: oldActiveItemIndex,
+    numberOfCards,
+  });
+
+  const previousItemIndex = infiniteLoopHelpers.getPreviousItemIndex({
+    activeItemIndex,
+    slidesToScroll,
+  });
+  const nextItemIndex = infiniteLoopHelpers.getNextItemIndex({
+    activeItemIndex,
+    slidesToScroll,
+  });
+  const activeItemTranslateX = infiniteLoopHelpers.getActiveItemTranslateX({
+    activeItemIndex,
+    activePosition,
+    containerWidth,
+    numberOfChildren: items.length,
+    numberOfCards,
+    gutter,
+    firstAndLastGutter,
+    showSlither,
+  });
+
+  const calculateActualTranslateX = currentTranslateX => {
+    const actualTranslateX = infiniteLoopHelpers.getActualTranslateX(items, currentTranslateX, {
+      activePosition,
+      containerWidth,
+      numberOfCards,
+      gutter,
+      firstAndLastGutter,
+      showSlither,
+    });
+
+    return userCalculateActualTranslateX(actualTranslateX);
+  }
+
+  return (
+    <Cpmt
+      {...props}
+      alwaysShowChevrons
+      activePosition={activePosition}
+      items={items}
+      previousItemIndex={previousItemIndex}
+      nextItemIndex={nextItemIndex}
+      activeItemIndex={activeItemIndex}
+      activeItemTranslateX={activeItemTranslateX}
+      calculateActualTranslateX={calculateActualTranslateX}
+    />
+  );
+};
+
+export default withInfiniteLoopCarouselValues;

--- a/src/ItemsCarousel/userPropTypes.js
+++ b/src/ItemsCarousel/userPropTypes.js
@@ -126,4 +126,14 @@ export default {
     rightChevronWrapper: PropTypes.string,
     leftChevronWrapper: PropTypes.string,
   }),
+
+  /**
+   * Enables infinite loop
+   */
+  infiniteLoop: PropTypes.bool,
+
+  /**
+   * Can be used change translateX on the spot
+   */
+  calculateActualTranslateX: PropTypes.func,
 };

--- a/src/ItemsCarousel/withCarouselValues.js
+++ b/src/ItemsCarousel/withCarouselValues.js
@@ -1,0 +1,55 @@
+import React from 'react';
+import {
+  calculateActiveItemTranslateX,
+  calculateNextIndex,
+  calculatePreviousIndex,
+} from './helpers'
+
+const withCarouselValues = () => (Cpmt) => (props) => {
+  const {
+    children,
+    activeItemIndex,
+    activePosition,
+    containerWidth,
+    numberOfCards,
+    slidesToScroll,
+    gutter,
+    firstAndLastGutter,
+    showSlither,
+  } = props;
+
+  const items = React.Children.toArray(children);
+
+  return (
+    <Cpmt
+      {...props}
+      items={items}
+      nextItemIndex={calculateNextIndex({
+        activePosition,
+        activeItemIndex,
+        numberOfCards,
+        slidesToScroll,
+        numberOfChildren: items.length,
+      })}
+      previousItemIndex={calculatePreviousIndex({
+        activePosition,
+        activeItemIndex,
+        numberOfCards,
+        slidesToScroll,
+        numberOfChildren: items.length,
+      })}
+      activeItemTranslateX={calculateActiveItemTranslateX({
+        activeItemIndex,
+        activePosition,
+        containerWidth,
+        numberOfChildren: items.length,
+        numberOfCards,
+        gutter,
+        firstAndLastGutter,
+        showSlither,
+      })}
+    />
+  );
+}
+
+export default withCarouselValues;

--- a/src/ItemsCarousel/withPlaceholderMode.js
+++ b/src/ItemsCarousel/withPlaceholderMode.js
@@ -44,11 +44,20 @@ export default () => (Cpmt) => {
       }, this.props.minimumPlaceholderTime);
     };
 
+    getPlaceholderItems = () => {
+      const {
+        placeholderItem,
+        numberOfPlaceholderItems,
+      } = this.props;
+
+      return Array.from(Array(numberOfPlaceholderItems)).map(index => placeholderItem);
+    };
+
     render() {
       return (
         <Cpmt
           {...this.props}
-          isPlaceholderMode={this.state.isPlaceholderMode}
+          items={this.state.isPlaceholderMode ? this.getPlaceholderItems() : this.props.items}
         />
       )
     }


### PR DESCRIPTION
This fixes #35 

# What I did
- Refactored the following carousel values to come from `withCarouselValues` hoc
  - `items`: array of nodes
  - `nextItemIndex`: number
  - `previousItemIndex`: number
  - `activeItemTranslateX`: number
- Added prop `calculateActualTranslateX` that will be called with the current translateX and can be used to change this value
- Created `withInfiniteLoopCarouselValues` hoc
- Added a hoc switcher to switch between `withCarouselValues` and `withInfiniteLoopCarouselValues` based on `infiniteLoop` prop. 