### PR TITLE
perf: removing styled-components from package dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "react-hot-loader": "^4.6.5",
     "react-tap-event-plugin": "^3.0.3",
     "style-loader": "^0.23.1",
+    "styled-components": "^4.4.0",
     "webpack": "^4.29.3",
     "webpack-cli": "^3.2.3",
     "webpack-dev-server": "^3.1.14",
@@ -67,7 +68,6 @@
     "prop-types": "^15.5.8",
     "react": "16.8.1",
     "react-measure": "^2.2.4",
-    "react-motion": "^0.5.2",
-    "styled-components": "^4.1.3"
+    "react-motion": "^0.5.2"
   }
 }

--- a/src/ItemsCarousel/ItemsCarouselBase.js
+++ b/src/ItemsCarousel/ItemsCarouselBase.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import { Motion, spring } from 'react-motion';
-import styled from 'styled-components';
 import PropTypes from 'prop-types';
 import userPropTypes from './userPropTypes';
 import {
@@ -13,47 +12,49 @@ import {
   calculatePreviousIndex,
 } from './helpers';
 
-const CarouselWrapper = styled.div`
-  position: relative;
-  ${(props) => props.height && `height: ${props.height}px;`}
-`;
+const getCarouselWrapperStyle = () => ({
+  position: 'relative',
+});
 
-const Wrapper = styled.div`
-  width: 100%;
-  overflow-x: hidden;
-`;
+const getWrapperStyle = () => ({
+  width: '100%',
+  overflowX: 'hidden',
+});
 
-const SliderItemsWrapper = styled.div`
-  width: 100%;
-  display: flex;
-  flex-wrap: nowrap;
-`;
+const getSliderItemsWrapperStyle = ({ translateX }) => ({
+  width: '100%',
+  display: 'flex',
+  flexWrap: 'nowrap',
+  transform: `translateX(${translateX * -1}px)`
+})
 
-const SliderItem = styled.div`
-  width: ${(props) => props.width}px;
-  flex-shrink: 0;
-  margin-right: ${(props) => props.rightGutter}px;
-  margin-left: ${(props) => props.leftGutter}px;
-`;
+const getSliderItemStyle = ({ width, rightGutter, leftGutter }) => ({
+  width,
+  flexShrink: 0,
+  marginRight: rightGutter,
+  marginLeft: leftGutter,
+});
 
-const CarouselChevron = styled.div`
-  position: absolute;
-  height: 100%;
-  width: ${(props) => props.chevronWidth + 1}px;
-  cursor: pointer;
-  top: 0;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-`;
+const getCarouselChevronStyle = (chevronWidth) => ({
+  position: 'absolute',
+  height: '100%',
+  width: chevronWidth + 1,
+  cursor: 'pointer',
+  top: 0,
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+});
 
-const CarouselRightChevron = styled(props => <CarouselChevron {...props} />)`
-  right: -${(props) => props.outsideChevron ? props.chevronWidth : 0}px;
-`;
+const getCarouselRightChevronStyle = ({ chevronWidth, outsideChevron }) => ({
+  ...getCarouselChevronStyle(chevronWidth),
+  right: outsideChevron ? -1 * chevronWidth : 0,
+});
 
-const CarouselLeftChevron = styled(props => <CarouselChevron {...props} />)`
-  left: -${(props) => props.outsideChevron ? props.chevronWidth : 0}px;
-`;
+const getCarouselLeftChevronStyle = ({ chevronWidth, outsideChevron }) => ({
+  ...getCarouselChevronStyle(chevronWidth),
+  left: outsideChevron ? -1 * chevronWidth : 0,
+});
 
 class ItemsCarouselBase extends React.Component {
   componentDidUpdate(prevProps) {
@@ -104,45 +105,45 @@ class ItemsCarouselBase extends React.Component {
       calculateActualTranslateX,
     } = this.props;
 
-    const actualTranslateX = calculateActualTranslateX(translateX);
-
     return (
-      <Wrapper className={classes.itemsWrapper}>
-        <SliderItemsWrapper
+      <div style={getWrapperStyle()} className={classes.itemsWrapper}>
+        <div
           ref={measureRef}
-          style={{
-            transform: `translateX(${actualTranslateX * -1}px)`,
-          }}
+          style={getSliderItemsWrapperStyle({
+            translateX: calculateActualTranslateX(translateX),
+          })}
           className={classes.itemsInnerWrapper}
         >
           {items.map((child, index) => (
-            <SliderItem
+            <div
               key={index}
+              style={getSliderItemStyle({
+                width: calculateItemWidth({
+                  firstAndLastGutter,
+                  containerWidth,
+                  gutter,
+                  numberOfCards,
+                  showSlither,
+                }),
+                leftGutter: calculateItemLeftGutter({
+                  index,
+                  firstAndLastGutter,
+                  gutter,
+                }),
+                rightGutter: calculateItemRightGutter({
+                  index,
+                  firstAndLastGutter,
+                  gutter,
+                  numberOfChildren: items.length,
+                }),
+              })}
               className={classes.itemWrapper}
-              width={calculateItemWidth({
-                firstAndLastGutter,
-                containerWidth,
-                gutter,
-                numberOfCards,
-                showSlither,
-              })}
-              leftGutter={calculateItemLeftGutter({
-                index,
-                firstAndLastGutter,
-                gutter,
-              })}
-              rightGutter={calculateItemRightGutter({
-                index,
-                firstAndLastGutter,
-                gutter,
-                numberOfChildren: items.length,
-              })}
             >
               {child}
-            </SliderItem>
+            </div>
           ))}
-        </SliderItemsWrapper>
-      </Wrapper>
+        </div>
+      </div>
     );
   }
 
@@ -185,7 +186,8 @@ class ItemsCarouselBase extends React.Component {
     const _showLeftChevron = leftChevron && (alwaysShowChevrons || !isFirstScroll);
 
     return (
-      <CarouselWrapper
+      <div
+        style={getCarouselWrapperStyle()}
         onTouchStart={onWrapperTouchStart}
         onTouchEnd={onWrapperTouchEnd}
         onTouchMove={onWrapperTouchMove}
@@ -207,27 +209,31 @@ class ItemsCarouselBase extends React.Component {
         />
         {
           _showRightChevron &&
-          <CarouselRightChevron
-            chevronWidth={chevronWidth}
-            outsideChevron={outsideChevron}
+          <div
+            style={getCarouselRightChevronStyle({
+              chevronWidth,
+              outsideChevron,
+            })}
             className={classes.rightChevronWrapper}
             onClick={() => requestToChangeActive(nextItemIndex)}
           >
             {rightChevron}
-          </CarouselRightChevron>
+          </div>
         }
         {
           _showLeftChevron &&
-          <CarouselLeftChevron
-            chevronWidth={chevronWidth}
-            outsideChevron={outsideChevron}
+          <div
+            style={getCarouselLeftChevronStyle({
+              chevronWidth,
+              outsideChevron,
+            })}
             className={classes.leftChevronWrapper}
             onClick={() => requestToChangeActive(previousItemIndex)}
           >
             {leftChevron}
-          </CarouselLeftChevron>
+          </div>
         }
-      </CarouselWrapper>
+      </div>
     );
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -668,19 +668,22 @@
     lodash "^4.17.11"
     to-fast-properties "^2.0.0"
 
-"@emotion/is-prop-valid@^0.7.3":
-  version "0.7.3"
-  resolved "https://registry.yarnpkg.com/@emotion/is-prop-valid/-/is-prop-valid-0.7.3.tgz#a6bf4fa5387cbba59d44e698a4680f481a8da6cc"
+"@emotion/is-prop-valid@^0.8.1":
+  version "0.8.3"
+  resolved "https://registry.yarnpkg.com/@emotion/is-prop-valid/-/is-prop-valid-0.8.3.tgz#cbe62ddbea08aa022cdf72da3971570a33190d29"
+  integrity sha512-We7VBiltAJ70KQA0dWkdPMXnYoizlxOXpvtjmu5/MBnExd+u0PGgV27WCYanmLAbCwAU30Le/xA0CQs/F/Otig==
   dependencies:
-    "@emotion/memoize" "0.7.1"
+    "@emotion/memoize" "0.7.3"
 
-"@emotion/memoize@0.7.1":
-  version "0.7.1"
-  resolved "https://registry.yarnpkg.com/@emotion/memoize/-/memoize-0.7.1.tgz#e93c13942592cf5ef01aa8297444dc192beee52f"
+"@emotion/memoize@0.7.3":
+  version "0.7.3"
+  resolved "https://registry.yarnpkg.com/@emotion/memoize/-/memoize-0.7.3.tgz#5b6b1c11d6a6dddf1f2fc996f74cf3b219644d78"
+  integrity sha512-2Md9mH6mvo+ygq1trTeVp2uzAKwE2P7In0cRpD/M9Q70aH8L+rxMLbb3JCN2JoSWsV2O+DdFjfbbXoMoLBczow==
 
 "@emotion/unitless@^0.7.0":
-  version "0.7.3"
-  resolved "https://registry.yarnpkg.com/@emotion/unitless/-/unitless-0.7.3.tgz#6310a047f12d21a1036fb031317219892440416f"
+  version "0.7.4"
+  resolved "https://registry.yarnpkg.com/@emotion/unitless/-/unitless-0.7.4.tgz#a87b4b04e5ae14a88d48ebef15015f6b7d1f5677"
+  integrity sha512-kBa+cDHOR9jpRJ+kcGMsysrls0leukrm68DmFQoMIWQcXdr2cZvyvypWuGYT7U+9kAExUE7+T7r6G3C3A6L8MQ==
 
 "@types/hoist-non-react-statics@^3.3.1":
   version "3.3.1"
@@ -1144,17 +1147,19 @@ babel-loader@^8.0.5:
     util.promisify "^1.0.0"
 
 "babel-plugin-styled-components@>= 1":
-  version "1.10.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-styled-components/-/babel-plugin-styled-components-1.10.0.tgz#ff1f42ad2cc78c21f26b62266b8f564dbc862939"
+  version "1.10.6"
+  resolved "https://registry.yarnpkg.com/babel-plugin-styled-components/-/babel-plugin-styled-components-1.10.6.tgz#f8782953751115faf09a9f92431436912c34006b"
+  integrity sha512-gyQj/Zf1kQti66100PhrCRjI5ldjaze9O0M3emXRPAN80Zsf8+e1thpTpaXJXVHXtaM4/+dJEgZHyS9Its+8SA==
   dependencies:
     "@babel/helper-annotate-as-pure" "^7.0.0"
     "@babel/helper-module-imports" "^7.0.0"
     babel-plugin-syntax-jsx "^6.18.0"
-    lodash "^4.17.10"
+    lodash "^4.17.11"
 
 babel-plugin-syntax-jsx@^6.18.0:
   version "6.18.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz#0af32a9a6e13ca7a3fd5069e62d7b0f58d0d8946"
+  integrity sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY=
 
 babel-runtime@6.x, babel-runtime@^6.23.0, babel-runtime@^6.26.0:
   version "6.26.0"
@@ -1420,6 +1425,7 @@ camelcase@^5.2.0:
 camelize@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/camelize/-/camelize-1.0.0.tgz#164a5483e630fa4321e5af07020e531831b2609b"
+  integrity sha1-FkpUg+Yw+kMh5a8HAg5TGDGyYJs=
 
 caniuse-lite@^1.0.30000929:
   version "1.0.30000936"
@@ -1785,6 +1791,7 @@ css-animation@1.x, css-animation@^1.3.2, css-animation@^1.5.0:
 css-color-keywords@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/css-color-keywords/-/css-color-keywords-1.0.0.tgz#fea2616dc676b2962686b3af8dbdbe180b244e05"
+  integrity sha1-/qJhbcZ2spYmhrOvjb2+GAskTgU=
 
 css-loader@^2.1.1:
   version "2.1.1"
@@ -1814,8 +1821,9 @@ css-select@^1.1.0:
     nth-check "~1.0.1"
 
 css-to-react-native@^2.2.2:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/css-to-react-native/-/css-to-react-native-2.3.0.tgz#bf80d24ec4a08e430306ef429c0586e6ed5485f7"
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/css-to-react-native/-/css-to-react-native-2.3.2.tgz#e75e2f8f7aa385b4c3611c52b074b70a002f2e7d"
+  integrity sha512-VOFaeZA053BqvvvqIA8c9n0+9vFppVBAHCp6JgFTtTMU3Mzi+XnelJ9XC9ul3BqFzZyQ5N+H0SnwsWT2Ebchxw==
   dependencies:
     camelize "^1.0.0"
     css-color-keywords "^1.0.0"
@@ -3271,6 +3279,11 @@ is-symbol@^1.0.2:
   dependencies:
     has-symbols "^1.0.0"
 
+is-what@^3.3.1:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/is-what/-/is-what-3.3.1.tgz#79502181f40226e2d8c09226999db90ef7c1bcbe"
+  integrity sha512-seFn10yAXy+yJlTRO+8VfiafC+0QJanGLMPTBWLrJm/QPauuchy0UXh8B6H5o9VA8BAzk0iYievt6mNp6gfaqA==
+
 is-windows@^1.0.0, is-windows@^1.0.1, is-windows@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-1.0.2.tgz#d1850eb9791ecd18e6182ce12a30f396634bb19d"
@@ -3583,9 +3596,10 @@ mem@^4.0.0:
     mimic-fn "^1.0.0"
     p-is-promise "^2.0.0"
 
-memoize-one@^4.0.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/memoize-one/-/memoize-one-4.1.0.tgz#a2387c58c03fff27ca390c31b764a79addf3f906"
+memoize-one@^5.0.0:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/memoize-one/-/memoize-one-5.1.1.tgz#047b6e3199b508eaec03504de71229b8eb1d75c0"
+  integrity sha512-HKeeBpWvqiVJD57ZUAsJNm71eHTykffzcLZVYWiVfQeI1rJtuEaS7hQiEpWfVVk18donPwJEcFKIkCmPJNOhHA==
 
 memory-fs@^0.4.0, memory-fs@~0.4.1:
   version "0.4.1"
@@ -3593,6 +3607,13 @@ memory-fs@^0.4.0, memory-fs@~0.4.1:
   dependencies:
     errno "^0.1.3"
     readable-stream "^2.0.1"
+
+merge-anything@^2.2.4:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/merge-anything/-/merge-anything-2.4.1.tgz#e9bccaec1e49ec6cb5f77ca78c5770d1a35315e6"
+  integrity sha512-dYOIAl9GFCJNctSIHWOj9OJtarCjsD16P8ObCl6oxrujAG+kOvlwJuOD9/O9iYZ9aTi1RGpGTG9q9etIvuUikQ==
+  dependencies:
+    is-what "^3.3.1"
 
 merge-descriptors@1.0.1:
   version "1.0.1"
@@ -4953,14 +4974,19 @@ react-hot-loader@^4.6.5:
     shallowequal "^1.0.2"
     source-map "^0.7.3"
 
-react-is@^16.6.0, react-is@^16.8.1:
-  version "16.8.1"
-  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.8.1.tgz#a80141e246eb894824fb4f2901c0c50ef31d4cdb"
+react-is@^16.6.0:
+  version "16.10.2"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.10.2.tgz#984120fd4d16800e9a738208ab1fba422d23b5ab"
+  integrity sha512-INBT1QEgtcCCgvccr5/86CfD71fw9EPmDxgiJX4I2Ddr6ZsV6iFXsuby+qWJPtmNuMY0zByTsG4468P7nHuNWA==
 
 react-is@^16.7.0:
   version "16.8.6"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.8.6.tgz#5bbc1e2d29141c9fbdfed456343fe2bc430a6a16"
   integrity sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA==
+
+react-is@^16.8.1:
+  version "16.8.1"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.8.1.tgz#a80141e246eb894824fb4f2901c0c50ef31d4cdb"
 
 react-lazy-load@^3.0.13:
   version "3.0.13"
@@ -5686,16 +5712,19 @@ style-loader@^0.23.1:
     loader-utils "^1.1.0"
     schema-utils "^1.0.0"
 
-styled-components@^4.1.3:
-  version "4.1.3"
-  resolved "https://registry.yarnpkg.com/styled-components/-/styled-components-4.1.3.tgz#4472447208e618b57e84deaaeb6acd34a5e0fe9b"
+styled-components@^4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/styled-components/-/styled-components-4.4.0.tgz#4e381e2dab831d0e6ea431c2840a96323e84e21b"
+  integrity sha512-xQ6vTI/0zNjZ1BBDRxyjvBddrxhQ3DxjeCdaLM1lSn5FDnkTOQgRkmWvcUiTajqc5nJqKVl+7sUioMqktD0+Zw==
   dependencies:
     "@babel/helper-module-imports" "^7.0.0"
-    "@emotion/is-prop-valid" "^0.7.3"
+    "@babel/traverse" "^7.0.0"
+    "@emotion/is-prop-valid" "^0.8.1"
     "@emotion/unitless" "^0.7.0"
     babel-plugin-styled-components ">= 1"
     css-to-react-native "^2.2.2"
-    memoize-one "^4.0.0"
+    memoize-one "^5.0.0"
+    merge-anything "^2.2.4"
     prop-types "^15.5.4"
     react-is "^16.6.0"
     stylis "^3.5.0"
@@ -5705,10 +5734,12 @@ styled-components@^4.1.3:
 stylis-rule-sheet@^0.0.10:
   version "0.0.10"
   resolved "https://registry.yarnpkg.com/stylis-rule-sheet/-/stylis-rule-sheet-0.0.10.tgz#44e64a2b076643f4b52e5ff71efc04d8c3c4a430"
+  integrity sha512-nTbZoaqoBnmK+ptANthb10ZRZOGC+EmTLLUxeYIuHNkEKcmKgXX1XWKkUBT2Ac4es3NybooPe0SmvKdhKJZAuw==
 
 stylis@^3.5.0:
   version "3.5.4"
   resolved "https://registry.yarnpkg.com/stylis/-/stylis-3.5.4.tgz#f665f25f5e299cf3d64654ab949a57c768b73fbe"
+  integrity sha512-8/3pSmthWM7lsPBKv7NXkzn2Uc9W7NotcwGNpJaa3k7WMM1XDCA4MgT5k/8BIexd5ydZdboXtU90XH9Ec4Bv/Q==
 
 supports-color@^5.1.0, supports-color@^5.3.0, supports-color@^5.5.0:
   version "5.5.0"


### PR DESCRIPTION
# Problem
Currently this package depends on `styled-components` which based on https://bundlephobia.com/result?p=styled-components@4.1.3 adds `43.1KB` in case you weren't using styled-components in your project

# Solution
This PR is an attempt to remove styled-components but still support old browsers

# Help wanted
The problem with the current PR is that it doesn't add vendor prefixes, these are the suggested solutions:
- Use a react vendor prefixer.
- Switch to a css module (BREAKING CHANGE).
- Drop support for old browsers.