### PR TITLE
Fix width attribute being applied to carousel item div

### DIFF
--- a/src/ItemsCarousel/ItemsCarouselBase.js
+++ b/src/ItemsCarousel/ItemsCarouselBase.js
@@ -29,8 +29,8 @@ const SliderItemsWrapper = styled.div`
   flex-wrap: nowrap;
 `;
 
-const SliderItem = styled.div`
-  width: ${(props) => props.width}px;
+const SliderItem = styled(({width, ...props}) => <div {...props} />)`
+  width: ${props => props.width}px;
   flex-shrink: 0;
   margin-right: ${(props) => props.rightGutter}px;
   margin-left: ${(props) => props.leftGutter}px;


### PR DESCRIPTION
Styled components applies the width value as a div attribute as well as a CSS style.
This is causing an issue with my implementation, this is a workaround I have found to alleviate this issue.