### PR TITLE
Fix componentWillReceiveProps warning on tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,12 +62,12 @@
     "webpack-node-externals": "^1.7.2"
   },
   "dependencies": {
+    "@serprex/react-motion": "^0.6.3",
     "lodash.max": "^4.0.1",
     "lodash.min": "^4.0.1",
     "prop-types": "^15.5.8",
     "react": "16.8.1",
     "react-measure": "^2.2.4",
-    "react-motion": "^0.5.2",
     "styled-components": "^4.1.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "webpack-node-externals": "^1.7.2"
   },
   "dependencies": {
-    "@serprex/react-motion": "^0.6.3",
+    "@korbav/react-motion": "^0.0.2",
     "lodash.max": "^4.0.1",
     "lodash.min": "^4.0.1",
     "prop-types": "^15.5.8",

--- a/src/ItemsCarousel/ItemsCarouselBase.js
+++ b/src/ItemsCarousel/ItemsCarouselBase.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Motion, spring } from 'react-motion';
+import { Motion, spring } from '@serprex/react-motion';
 import styled from 'styled-components';
 import PropTypes from 'prop-types';
 import userPropTypes from './userPropTypes';

--- a/src/ItemsCarousel/ItemsCarouselBase.js
+++ b/src/ItemsCarousel/ItemsCarouselBase.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Motion, spring } from '@serprex/react-motion';
+import { Motion, spring } from '@korbav/react-motion';
 import styled from 'styled-components';
 import PropTypes from 'prop-types';
 import userPropTypes from './userPropTypes';

--- a/yarn.lock
+++ b/yarn.lock
@@ -682,6 +682,15 @@
   version "0.7.3"
   resolved "https://registry.yarnpkg.com/@emotion/unitless/-/unitless-0.7.3.tgz#6310a047f12d21a1036fb031317219892440416f"
 
+"@serprex/react-motion@^0.6.3":
+  version "0.6.3"
+  resolved "https://registry.yarnpkg.com/@serprex/react-motion/-/react-motion-0.6.3.tgz#1b4df35ade0150af08d4837da7d08cbc398e08a3"
+  integrity sha512-TC5QpaMFVLTSKoWisGvUvavNvlnjeDlXvSGR+uNVZRXmj85DZWtL3S1oobbGTXOsbGCo3u2c/IM8cjmPegOIGQ==
+  dependencies:
+    performance-now "^2.1.0"
+    prop-types "^15.5.8"
+    raf "^3.1.0"
+
 "@types/hoist-non-react-statics@^3.3.1":
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz#1124aafe5118cb591977aeb1ceaaed1070eb039f"
@@ -4227,10 +4236,6 @@ pbkdf2@^3.0.3:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
-performance-now@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-0.2.0.tgz#33ef30c5c77d4ea21c5a53869d91b56d8f2555e5"
-
 performance-now@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
@@ -5006,14 +5011,6 @@ react-measure@^2.2.4:
     get-node-dimensions "^1.2.1"
     prop-types "^15.6.2"
     resize-observer-polyfill "^1.5.0"
-
-react-motion@^0.5.2:
-  version "0.5.2"
-  resolved "https://registry.yarnpkg.com/react-motion/-/react-motion-0.5.2.tgz#0dd3a69e411316567927917c6626551ba0607316"
-  dependencies:
-    performance-now "^0.2.0"
-    prop-types "^15.5.8"
-    raf "^3.1.0"
 
 react-slick@~0.23.2:
   version "0.23.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -682,11 +682,12 @@
   version "0.7.3"
   resolved "https://registry.yarnpkg.com/@emotion/unitless/-/unitless-0.7.3.tgz#6310a047f12d21a1036fb031317219892440416f"
 
-"@serprex/react-motion@^0.6.3":
-  version "0.6.3"
-  resolved "https://registry.yarnpkg.com/@serprex/react-motion/-/react-motion-0.6.3.tgz#1b4df35ade0150af08d4837da7d08cbc398e08a3"
-  integrity sha512-TC5QpaMFVLTSKoWisGvUvavNvlnjeDlXvSGR+uNVZRXmj85DZWtL3S1oobbGTXOsbGCo3u2c/IM8cjmPegOIGQ==
+"@korbav/react-motion@^0.0.2":
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/@korbav/react-motion/-/react-motion-0.0.2.tgz#7104ca2c8387dcf74e00f0e7a07382a558389954"
+  integrity sha512-XLWct1ol7MAOn9iSLBDpbcwaHLUGVgXXmMFsYaGL1tz/A/Nt9MOGd7GyZ7Zd/fW/0/Zk4D3Wf8ckrhZbbPFheA==
   dependencies:
+    lodash.isequal "^4.5.0"
     performance-now "^2.1.0"
     prop-types "^15.5.8"
     raf "^3.1.0"


### PR DESCRIPTION
## What this PR does?
Use [@korbav/react-motion](https://github.com/korbav/react-motion) instead of [react-motion](https://github.com/chenglou/react-motion) 

## Why?
The react-motion library seems to not have support anymore, this causes a warning described in this issue https://github.com/kareemaly/react-items-carousel/issues/79

_This warning shows when you use the React.StrictMode_
In order to test if the warning was solved, I created a test with testing library using the AutoPlay component
The code is in the end of this PR

## How?
Following this issue https://github.com/chenglou/react-motion/issues/604, @serprex cited how to fix the warning with a react-17 compatible version of the motion library created by @korbav

This PR replace the react-motion with the fix that korbav made!



## How I tested if the warning was gone
1. Using strict mode in `src/ItemsCarousel/ItemsCarouselBase.js` line 187
2. Configuring babel with this presset
`babel.config.js`
```
module.exports = {
  presets: ["@babel/preset-env", "@babel/preset-react"],
  plugins: ["@babel/plugin-proposal-class-properties"]
};
```

3. Using this test
```js
import React from "react";
import { render } from "@testing-library/react";
import AutoPlayCarousel from "./gh/components/AutoPlayCarousel";

describe("testing Header component", () => {
  test("should snapshot works with english language", () => {
    const { container } = render(<AutoPlayCarousel />, {
      initialState: null
    });

    expect(container).toMatchSnapshot();
  });
});
```