### PR TITLE
fix(helpers): condition to check if we reached the end of the carousel for translateX

### DIFF
--- a/src/ItemsCarousel/helpers.js
+++ b/src/ItemsCarousel/helpers.js
@@ -118,7 +118,7 @@ export const calculateActiveItemTranslateX = ({
   }
 
   // Last items to show
-  if(!infiniteLoop && gotoIndex > (numberOfChildren - numberOfCards - 1)) {
+  if(!infiniteLoop && gotoIndex > (numberOfChildren - numberOfCards)) {
     return calculateLastPossibleTranslateX({
       activeItemIndex: gotoIndex,
       activePosition,


### PR DESCRIPTION
This PR fixes the following bug :

![Animation](https://user-images.githubusercontent.com/81616372/220384767-134f8f2e-018f-49cf-a639-727ce86b7866.gif)
As you can see the right arrow is still displayed when we reach the end of the carousel.

You can reproduce this bug with this configuration: 
```json
{
  "noOfChildren": 4,
  "wrapperStyle": {
    "padding": "0 60px",
    "maxWidth": 763,
    "margin": "0 auto"
  },
  "componentProps": {
    "infiniteLoop": false,
    "activePosition": "left",
    "numberOfCards": 1.8,
    "slidesToScroll": 1.8
  }
}
```